### PR TITLE
Fix: release build failed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 on:
   push:
     branches:
-      - master
+      - fix/ci
     tags-ignore:
       - '**'
     paths-ignore:
@@ -108,7 +108,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         if: ${{ !matrix.settings.docker }}
         with:
-          toolchain: nightly-2023-12-28
+          toolchain: nightly-2024-09-05
           targets: ${{ matrix.settings.target }}
 
       - name: Cache cargo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,8 @@ jobs:
             name: darwin-x64
             target: x86_64-apple-darwin
             build: |
-              cd crates/node_binding
+              cd crates/node_binding &&
+              rustup target add x86_64-apple-darwin &&
               pnpm build --target x86_64-apple-darwin
               strip -x *.node
           - host: macos-latest
@@ -48,13 +49,15 @@ jobs:
             target: aarch64-pc-windows-msvc
             name:  win32-arm64-msvc
             build: |
-              cd crates/node_binding
+              cd crates/node_binding &&
+              rustup target add aarch64-pc-windows-msvc &&
               pnpm build --target aarch64-pc-windows-msvc
           - host: windows-latest
             target: i686-pc-windows-msvc
             name:  win32-ia32-msvc
             build: |
-              cd crates/node_binding
+              cd crates/node_binding &&
+              rustup target add i686-pc-windows-msvc &&
               pnpm build --target i686-pc-windows-msvc 
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
 on:
   push:
     branches:
-      - fix/ci
+      - master
     tags-ignore:
       - '**'
     paths-ignore:
@@ -24,56 +24,56 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          # - host: macos-latest
-          #   name: darwin-x64
-          #   target: x86_64-apple-darwin
-          #   build: |
-          #     cd crates/node_binding &&
-          #     rustup target add x86_64-apple-darwin &&
-          #     pnpm build --target x86_64-apple-darwin
-          #     strip -x *.node
-          # - host: macos-latest
-          #   name: darwin-arm64
-          #   target: aarch64-apple-darwin
-          #   build: |
-          #     cd crates/node_binding
-          #     pnpm build --target aarch64-apple-darwin
-          #     strip -x *.node
-          # - host: windows-latest
-          #   name: win32-x64-msvc
-          #   target: x86_64-pc-windows-msvc
-          #   build: |
-          #     cd crates/node_binding
-          #     pnpm build --target x86_64-pc-windows-msvc
-          # - host: windows-latest
-          #   target: aarch64-pc-windows-msvc
-          #   name:  win32-arm64-msvc
-          #   build: |
-          #     cd crates/node_binding &&
-          #     rustup target add aarch64-pc-windows-msvc &&
-          #     pnpm build --target aarch64-pc-windows-msvc
-          # - host: windows-latest
-          #   target: i686-pc-windows-msvc
-          #   name:  win32-ia32-msvc
-          #   build: |
-          #     cd crates/node_binding &&
-          #     rustup target add i686-pc-windows-msvc &&
-          #     pnpm build --target i686-pc-windows-msvc 
-          # - host: ubuntu-latest
-          #   target: x86_64-unknown-linux-gnu
-          #   name: linux-x64-gnu
-          #   docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
-          #   build: |-
-          #     set -e &&
-          #     cd crates/node_binding &&
-          #     unset CC_x86_64_unknown_linux_gnu && unset CC &&
-          #     pnpm build --target x86_64-unknown-linux-gnu &&
-          #     strip *.node
-          # - host: ubuntu-latest
-          #   name: linux-x64-musl
-          #   target: x86_64-unknown-linux-musl
-          #   docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-          #   build: cd crates/node_binding && set -e && pnpm build && strip *.node
+          - host: macos-latest
+            name: darwin-x64
+            target: x86_64-apple-darwin
+            build: |
+              cd crates/node_binding &&
+              rustup target add x86_64-apple-darwin &&
+              pnpm build --target x86_64-apple-darwin
+              strip -x *.node
+          - host: macos-latest
+            name: darwin-arm64
+            target: aarch64-apple-darwin
+            build: |
+              cd crates/node_binding
+              pnpm build --target aarch64-apple-darwin
+              strip -x *.node
+          - host: windows-latest
+            name: win32-x64-msvc
+            target: x86_64-pc-windows-msvc
+            build: |
+              cd crates/node_binding
+              pnpm build --target x86_64-pc-windows-msvc
+          - host: windows-latest
+            target: aarch64-pc-windows-msvc
+            name:  win32-arm64-msvc
+            build: |
+              cd crates/node_binding &&
+              rustup target add aarch64-pc-windows-msvc &&
+              pnpm build --target aarch64-pc-windows-msvc
+          - host: windows-latest
+            target: i686-pc-windows-msvc
+            name:  win32-ia32-msvc
+            build: |
+              cd crates/node_binding &&
+              rustup target add i686-pc-windows-msvc &&
+              pnpm build --target i686-pc-windows-msvc 
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            name: linux-x64-gnu
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+            build: |-
+              set -e &&
+              cd crates/node_binding &&
+              unset CC_x86_64_unknown_linux_gnu && unset CC &&
+              pnpm build --target x86_64-unknown-linux-gnu &&
+              strip *.node
+          - host: ubuntu-latest
+            name: linux-x64-musl
+            target: x86_64-unknown-linux-musl
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            build: cd crates/node_binding && set -e && pnpm build && strip *.node
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             name: linux-arm64-gnu
@@ -85,17 +85,17 @@ jobs:
               rustup target add aarch64-unknown-linux-gnu &&
               pnpm build --target aarch64-unknown-linux-gnu &&
               aarch64-unknown-linux-gnu-strip *.node
-          # - host: ubuntu-latest
-          #   target: aarch64-unknown-linux-musl
-          #   name: linux-arm64-musl
-          #   docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-          #   build: |-
-          #     set -e &&
-          #     cd crates/node_binding &&
-          #     export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc &&
-          #     rustup target add aarch64-unknown-linux-musl &&
-          #     pnpm build --target aarch64-unknown-linux-musl &&
-          #     /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip *.node
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            name: linux-arm64-musl
+            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+            build: |-
+              set -e &&
+              cd crates/node_binding &&
+              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc &&
+              rustup target add aarch64-unknown-linux-musl &&
+              pnpm build --target aarch64-unknown-linux-musl &&
+              /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip *.node
     name: stable - ${{ matrix.settings.target }} - node@18
     runs-on: ${{ matrix.settings.host }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,56 +24,56 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-latest
-            name: darwin-x64
-            target: x86_64-apple-darwin
-            build: |
-              cd crates/node_binding &&
-              rustup target add x86_64-apple-darwin &&
-              pnpm build --target x86_64-apple-darwin
-              strip -x *.node
-          - host: macos-latest
-            name: darwin-arm64
-            target: aarch64-apple-darwin
-            build: |
-              cd crates/node_binding
-              pnpm build --target aarch64-apple-darwin
-              strip -x *.node
-          - host: windows-latest
-            name: win32-x64-msvc
-            target: x86_64-pc-windows-msvc
-            build: |
-              cd crates/node_binding
-              pnpm build --target x86_64-pc-windows-msvc
-          - host: windows-latest
-            target: aarch64-pc-windows-msvc
-            name:  win32-arm64-msvc
-            build: |
-              cd crates/node_binding &&
-              rustup target add aarch64-pc-windows-msvc &&
-              pnpm build --target aarch64-pc-windows-msvc
-          - host: windows-latest
-            target: i686-pc-windows-msvc
-            name:  win32-ia32-msvc
-            build: |
-              cd crates/node_binding &&
-              rustup target add i686-pc-windows-msvc &&
-              pnpm build --target i686-pc-windows-msvc 
-          - host: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            name: linux-x64-gnu
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
-            build: |-
-              set -e &&
-              cd crates/node_binding &&
-              unset CC_x86_64_unknown_linux_gnu && unset CC &&
-              pnpm build --target x86_64-unknown-linux-gnu &&
-              strip *.node
-          - host: ubuntu-latest
-            name: linux-x64-musl
-            target: x86_64-unknown-linux-musl
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-            build: cd crates/node_binding && set -e && pnpm build && strip *.node
+          # - host: macos-latest
+          #   name: darwin-x64
+          #   target: x86_64-apple-darwin
+          #   build: |
+          #     cd crates/node_binding &&
+          #     rustup target add x86_64-apple-darwin &&
+          #     pnpm build --target x86_64-apple-darwin
+          #     strip -x *.node
+          # - host: macos-latest
+          #   name: darwin-arm64
+          #   target: aarch64-apple-darwin
+          #   build: |
+          #     cd crates/node_binding
+          #     pnpm build --target aarch64-apple-darwin
+          #     strip -x *.node
+          # - host: windows-latest
+          #   name: win32-x64-msvc
+          #   target: x86_64-pc-windows-msvc
+          #   build: |
+          #     cd crates/node_binding
+          #     pnpm build --target x86_64-pc-windows-msvc
+          # - host: windows-latest
+          #   target: aarch64-pc-windows-msvc
+          #   name:  win32-arm64-msvc
+          #   build: |
+          #     cd crates/node_binding &&
+          #     rustup target add aarch64-pc-windows-msvc &&
+          #     pnpm build --target aarch64-pc-windows-msvc
+          # - host: windows-latest
+          #   target: i686-pc-windows-msvc
+          #   name:  win32-ia32-msvc
+          #   build: |
+          #     cd crates/node_binding &&
+          #     rustup target add i686-pc-windows-msvc &&
+          #     pnpm build --target i686-pc-windows-msvc 
+          # - host: ubuntu-latest
+          #   target: x86_64-unknown-linux-gnu
+          #   name: linux-x64-gnu
+          #   docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian
+          #   build: |-
+          #     set -e &&
+          #     cd crates/node_binding &&
+          #     unset CC_x86_64_unknown_linux_gnu && unset CC &&
+          #     pnpm build --target x86_64-unknown-linux-gnu &&
+          #     strip *.node
+          # - host: ubuntu-latest
+          #   name: linux-x64-musl
+          #   target: x86_64-unknown-linux-musl
+          #   docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+          #   build: cd crates/node_binding && set -e && pnpm build && strip *.node
           - host: ubuntu-latest
             target: aarch64-unknown-linux-gnu
             name: linux-arm64-gnu
@@ -81,21 +81,21 @@ jobs:
             build: |-
               set -e &&
               cd crates/node_binding &&
-              export JEMALLOC_SYS_WITH_LG_PAGE=16 && export CC_aarch64_unknown_linux_gnu=/usr/aarch64-unknown-linux-gnu/bin/aarch64-unknown-linux-gnu-gcc &&
+              export JEMALLOC_SYS_WITH_LG_PAGE=16 && export CC_aarch64_unknown_linux_gnu=clang &&
               rustup target add aarch64-unknown-linux-gnu &&
               pnpm build --target aarch64-unknown-linux-gnu &&
               aarch64-unknown-linux-gnu-strip *.node
-          - host: ubuntu-latest
-            target: aarch64-unknown-linux-musl
-            name: linux-arm64-musl
-            docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
-            build: |-
-              set -e &&
-              cd crates/node_binding &&
-              export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc &&
-              rustup target add aarch64-unknown-linux-musl &&
-              pnpm build --target aarch64-unknown-linux-musl &&
-              /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip *.node
+          # - host: ubuntu-latest
+          #   target: aarch64-unknown-linux-musl
+          #   name: linux-arm64-musl
+          #   docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
+          #   build: |-
+          #     set -e &&
+          #     cd crates/node_binding &&
+          #     export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc &&
+          #     rustup target add aarch64-unknown-linux-musl &&
+          #     pnpm build --target aarch64-unknown-linux-musl &&
+          #     /aarch64-linux-musl-cross/bin/aarch64-linux-musl-strip *.node
     name: stable - ${{ matrix.settings.target }} - node@18
     runs-on: ${{ matrix.settings.host }}
     steps:


### PR DESCRIPTION
This pull request includes several changes to the `.github/workflows/release.yml` file to improve the CI/CD pipeline. The most important changes include updating the branch name for the workflow trigger, adding Rust targets for specific builds, and updating the Rust toolchain version.

Workflow trigger update:
* Changed the branch name from `master` to `fix/ci` in the `push` event configuration.

Build process improvements:
* Updated the build steps to include `rustup target add` commands for the `darwin-x64`, `win32-arm64-msvc`, and `win32-ia32-msvc` targets. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L31-R32) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L51-R60)

Toolchain update:
* Updated the Rust toolchain from `nightly-2023-12-28` to `nightly-2024-09-05` in the `jobs` configuration.